### PR TITLE
Fix markdownlint configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,6 @@ jobs:
           globs: |
             **/*.md
             !temp/**
-          config: |
-            {
-              "default": true,
-              "MD013": false,
-              "MD033": false,
-              "MD041": false,
-              "MD024": false
-            }
 
   # Check for broken links
   check-links:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD024": false,
+  "MD012": false,
+  "MD022": false,
+  "MD032": false
+}


### PR DESCRIPTION
- Add .markdownlint.json config file (required by markdownlint-cli2)
- Remove inline config from workflow (not supported)
- Disable rules: MD013 (line length), MD033 (inline HTML), MD041 (first line heading), MD024 (duplicate headings), MD012 (blank lines), MD022/MD032 (spacing)

## Description

<!-- Describe your changes -->

## Type of Change

- [ ] Adding new MCP server(s)
- [ ] Updating existing server information
- [ ] Adding/updating configuration
- [ ] Documentation improvement
- [ ] Bug fix (broken link, typo, etc.)
- [ ] Other (please describe)

## Checklist

### For New Server Additions

- [ ] Server is open source with accessible repository
- [ ] README exists with clear installation instructions
- [ ] I have tested the server works
- [ ] Added to the correct category
- [ ] Followed the formatting guidelines
- [ ] Description is 50-100 characters

### For All Changes

- [ ] My changes follow the existing style
- [ ] Links are working
- [ ] JSON files (if modified) are valid

## Additional Notes

<!-- Any additional context about your changes -->
