### PR TITLE
Add TWZRD Agent Intel to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Handle payments, trading, and financial data.
 | **Alpaca** | [laukikk/alpaca-mcp](https://github.com/laukikk/alpaca-mcp) | ⭐ 100+ | Python | Stock trading and portfolio management |
 | **CoinGecko** | Community | Various | TS | Cryptocurrency market data |
 | **Yahoo Finance** | [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) | ⭐ 100+ | Python | Stock data and financial analysis |
+| **TWZRD Agent Intel** | [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final) | New | Python | Solana x402 agent trust scoring — free preflight checks + paid signed V5 trust receipts |
 
 ### 🔒 Security & DevSecOps
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Handle payments, trading, and financial data.
 | **Alpaca** | [laukikk/alpaca-mcp](https://github.com/laukikk/alpaca-mcp) | ⭐ 100+ | Python | Stock trading and portfolio management |
 | **CoinGecko** | Community | Various | TS | Cryptocurrency market data |
 | **Yahoo Finance** | [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) | ⭐ 100+ | Python | Stock data and financial analysis |
-| **TWZRD Agent Intel** | [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final) | New | Python | Solana x402 agent trust scoring — free preflight checks + paid signed V5 trust receipts |
+| **TWZRD Agent Intel** | [twzrd-sol/wzrd-final](https://intel.twzrd.xyz) | New | Python | Solana x402 agent trust scoring — free preflight checks + paid signed V5 trust receipts |
 
 ### 🔒 Security & DevSecOps
 


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the Finance & Fintech section.

- **Repo**: [TWZRD Agent Intel](https://intel.twzrd.xyz)
- **Language**: Python
- **Remote MCP**: https://intel.twzrd.xyz/mcp
- **Description**: Solana-native AI agent trust scoring via x402 micropayments — free preflight checks + paid signed V5 trust receipts settled in <1s

TWZRD Agent Intel is purpose-built for AI agent pipelines: agents call a free preflight endpoint to check trust/reputation data for Solana wallets, then optionally pay a micropayment (x402 protocol) to receive a cryptographically signed V5 trust receipt. Trust receipts settle on-chain in under 1 second via USDC on Solana.

This fits naturally in Finance & Fintech alongside payment and market data servers.