### PR TITLE
Add The Stall — 210 pay-per-call MCP tools via x402 (Finance & Fintech)


### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Handle payments, trading, and financial data.
 | **Alpaca** | [laukikk/alpaca-mcp](https://github.com/laukikk/alpaca-mcp) | ⭐ 100+ | Python | Stock trading and portfolio management |
 | **CoinGecko** | Community | Various | TS | Cryptocurrency market data |
 | **Yahoo Finance** | [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) | ⭐ 100+ | Python | Stock data and financial analysis |
+| **The Stall** | [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) | New | JS | 191 pay-per-call data tools (stocks, DeFi, options, crypto, SEC filings, macro) — no API key, USDC micropayments via x402 |
 
 ### 🔒 Security & DevSecOps
 


### PR DESCRIPTION
## The Stall

**The Stall** is an MCP server with 209 pay-per-call data tools covering finance, crypto/DeFi, macro, and more. Agents pay per call in USDC on Base — no API keys, no subscriptions.

### Why it fits the Finance & Fintech section

Covers all the use cases already in this section, and more:
- **Equities:** US stock prices, OHLCV, analyst ratings, earnings, insider trades, congressional trades, short volume, dividend calendar
- **Derivatives:** Full options chain, options snapshot, IV data
- **Macro:** Treasury yields, FOMC tracker, CPI/PCE, IMF country outlook, economic calendar
- **DeFi:** DefiLlama protocols, yields, DEX quotes, funding rates, whale radar, token security
- **Crypto:** Top movers, fear/greed index, Polymarket probabilities, stablecoin watch, Korean market movers (Upbit)
- **Compliance:** SEC filings, sanctions screening, wallet credit score

### What makes it different

Unlike the other servers in this section (which require API keys), The Stall uses **x402 micropayments** — agents pay per call in USDC (~$0.003–$0.05/call). No setup, no key management, no subscription. Connect and go.

### Links
- GitHub: https://github.com/thebrierfox/the-stall
- Live: https://the-stall.intuitek.ai
- Smithery: https://smithery.ai/servers/thebrierfox/the-stall
- Glama: https://glama.ai/mcp/servers/thebrierfox/the-stall

### MCP config
```json
{
  "mcpServers": {
    "the-stall": {
      "url": "https://the-stall.intuitek.ai/mcp",
      "transport": "streamable-http"
    }
  }
}
```

### Submission criteria
- ✅ Open source (MIT) with active maintenance (v4.63.1, pushed 2026-06-09)
- ✅ Clear documentation (README + /catalog endpoint)
- ✅ Working installation (tested on Claude Code, Cursor, Claude Desktop)
- ✅ Follows MCP specification (streamable-http transport, /mcp endpoint)
