### PR TITLE
Add: NotFair - AI & ML (SEO & paid-ads agent skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Enhance AI capabilities and integrate with ML platforms.
 | **Hugging Face** | [evalstate/mcp-hfspace](https://github.com/evalstate/mcp-hfspace) | ⭐ 200+ | TS | Access HF Spaces and models |
 | **Replicate** | [awkoy/replicate-flux-mcp](https://github.com/awkoy/replicate-flux-mcp) | ⭐ 100+ | TS | Image generation via Replicate API |
 | **Context7** 🎖️ | [upstash/context7](https://github.com/upstash/context7) | ⭐ 500+ | TS | Up-to-date documentation for LLMs |
+| **NotFair** | [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) | ⭐ 2.9k+ | TS | Claude Code agent skills for SEO, Google Ads, and Meta Ads; connects via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP |
 
 ### 📱 Platform-Specific
 


### PR DESCRIPTION
## Server Information

- **Name**: NotFair
- **Repository**: [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)
- **Category**: AI & ML
- **Language**: TS

## Checklist

- [x] Server is open source
- [x] README exists with installation instructions
- [x] I've tested the server works
- [x] Added to correct category
- [x] Follows formatting guidelines

## Why This Server?

Thanks for maintaining this list — it's a genuinely useful resource.

NotFair (~2.9k stars, MIT license) is an open-source set of Claude Code agent skills for marketing work — covering SEO, Google Ads, and Meta Ads. What makes it relevant here is that it connects to live data through four MCP integrations: Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Those MCPs do the heavy lifting for pulling real account data into Claude Code.

It felt like a natural fit for the AI & ML section since it extends Claude Code with specialized marketing capabilities via MCP connections.

Happy to reword, move it to a different section, or trim the description if needed. Thanks for your time!