### PR TITLE
Add BuyWhere MCP server to Web & Search category

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Access the web, scrape content, and search the internet.
 | **Perplexity** | [tanigami/mcp-server-perplexity](https://github.com/tanigami/mcp-server-perplexity) | ⭐ 200+ | Python | Real-time web search with citations |
 | **Apify** 🎖️ | [apify/actors-mcp-server](https://github.com/apify/actors-mcp-server) | ⭐ 300+ | TS | 3,000+ pre-built web scrapers |
 | **Helium** | [connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp) | New | Python | Real-time news with bias scoring across 5,000+ sources, AI-powered options pricing, and live market data |
+| **BuyWhere** | [BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) | ⭐ 50+ | TS | Cross-border product search API for AI shopping agents — 8 tools, 150M+ products across SG, MY, TH, VN, PH, ID, US merchants |
 
 ### 📊 Productivity & Collaboration
 


### PR DESCRIPTION
## Server Information

- **Name**: BuyWhere MCP
- **Repository**: https://github.com/BuyWhere/buywhere-mcp
- **Category**: Web & Search (product search)
- **Language**: TypeScript

## Why This Server?

BuyWhere is a free cross-border product search API for AI shopping agents.

**Capabilities:**
- 8 MCP tools: `search_products`, `get_product`, `compare_products`, `get_deals`, `list_categories`, `find_best_price`, `find_similar`, `ingest_products`
- 150M+ products across Singapore, Malaysia, Thailand, Vietnam, Philippines, Indonesia, US merchants
- Real-time pricing & inventory
- Official MCP Registry entry (io.github.BuyWhere/buywhere-mcp, isLatest=true)
- Self-service API key — no signup required (POST /v1/auth/register)
- 2K+ weekly npm downloads
- Streamable-HTTP transport, works with Claude Desktop, Cursor, VS Code, Windsurf

## Checklist

- [x] Server is open source (MIT)
- [x] README exists with installation instructions
- [x] Server is tested and live (verified heartbeat at https://mcp.buywhere.ai)
- [x] Added to correct category (Web & Search — product search API)
- [x] Follows formatting guidelines

## Use Cases

AI shopping assistants can use BuyWhere for:
- Product discovery (search across millions of SKUs)
- Price comparison across merchants
- Deal alerts and discount tracking
- Inventory availability checks
- Cross-border shopping for SEA/US markets