### PR TITLE
Add 2s.io (@2sio/mcp) to Web & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Access the web, scrape content, and search the internet.
 | **Perplexity** | [tanigami/mcp-server-perplexity](https://github.com/tanigami/mcp-server-perplexity) | ⭐ 200+ | Python | Real-time web search with citations |
 | **Apify** 🎖️ | [apify/actors-mcp-server](https://github.com/apify/actors-mcp-server) | ⭐ 300+ | TS | 3,000+ pre-built web scrapers |
 | **Helium** | [connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp) | New | Python | Real-time news with bias scoring across 5,000+ sources, AI-powered options pricing, and live market data |
+| **2s.io** | [2s-io/sdk](https://github.com/2s-io/sdk) | New | TS | Keyless pay-per-call API for agents: 570+ live endpoints — web answers, patents, case law, KYB & sanctions screening, geo, weather, identity crosswalks, plus a chat/image AI gateway. Pays per request in USDC via x402, no signup or API key |
 
 ### 📊 Productivity & Collaboration
 


### PR DESCRIPTION
Adds **2s.io** under **📂 By Category → 🌐 Web & Search**.

- **Server:** 2s.io (`@2sio/mcp`)
- **Repo:** https://github.com/2s-io/sdk
- **Install:** `npx -y @2sio/mcp`
- **Lang:** TypeScript

A keyless, pay-per-call API for AI agents: 570+ live endpoints spanning web answers, patents, case law, company/KYB and sanctions screening, geocoding, weather, identity crosswalks, and a chat/image AI gateway. No signup or API key — each request settles a sub-cent USDC micropayment over the x402 protocol (HTTP 402) on Base, so agents can call it autonomously.

Meets submission criteria: open-source SDK/MCP (active, published to npm as `@2sio/mcp`), documented quick-start, working `npx` install, MCP-spec compliant.
