### PR TITLE
Add AgentServices — x402-paid crypto/market data MCP server (Finance & Fintech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Handle payments, trading, and financial data.
 | **CoinGecko** | Community | Various | TS | Cryptocurrency market data |
 | **Yahoo Finance** | [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) | ⭐ 100+ | Python | Stock data and financial analysis |
 | **The Stall** | [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) | New | JS | 191 pay-per-call data tools (stocks, DeFi, options, crypto, SEC filings, macro) — no API key, USDC micropayments via x402 |
+| **AgentServices** | [vbkotecha/agentservices](https://github.com/vbkotecha/agentservices) | ⭐ 50+ | Python | 54 crypto/market data services (97 endpoints, 37 MCP tools) with x402 on-chain payments |
 
 ### 🔒 Security & DevSecOps
 


### PR DESCRIPTION
## Summary

Adds AgentServices to the Finance & Fintech section.

AgentServices is a production x402-paid API platform providing crypto and market data to AI agents via MCP.

- **54 services** across 97 API endpoints
- **37 MCP tools** for AI agent consumption
- **x402 on-chain payments** (USDC on Base, micropayments from $0.01/call)
- **Streamable HTTP** transport
- Listed on official MCP Registry: `to.agentservices/agentservices` (v5.3.0)

Fits alongside The Stall in the Finance & Fintech section as a pay-per-call data marketplace for AI agents.

## Details

- **Repo:** https://github.com/vbkotecha/agentservices
- **MCP endpoint:** https://agentservices.to/mcp
- **API:** https://api.agentservices.to
- **OpenAPI:** https://api.agentservices.to/openapi.json

## Test plan

- [ ] Verify MCP endpoint responds: `curl -s https://agentservices.to/.well-known/mcp.json`
- [ ] Verify x402 challenge: `curl -s -o /dev/null -w "%{http_code}" https://api.agentservices.to/v1/fx` (expect 402)
- [ ] Verify OpenAPI spec: `curl -s https://api.agentservices.to/openapi.json | python3 -m json.tool`