### PR TITLE
Add SysKnife to Security & DevSecOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Scan, audit, and secure your applications.
 | **VirusTotal** | [BurtTheCoder/mcp-virustotal](https://github.com/BurtTheCoder/mcp-virustotal) | ⭐ 100+ | TS | URL/file scanning and threat analysis |
 | **Shodan** | [BurtTheCoder/mcp-shodan](https://github.com/BurtTheCoder/mcp-shodan) | ⭐ 100+ | TS | Internet-connected device search |
 | **DomScan** | [estevecastells/domscan-mcp](https://github.com/estevecastells/domscan-mcp) | New | JS | Domain, DNS, WHOIS/RDAP, TLS, subdomain, email and brand intelligence |
+| **SysKnife** | [lacs-project/sysknife](https://github.com/lacs-project/sysknife) | New | Rust | Linux sysadmin via typed actions, signed audit chain, human approval receipts |
 
 ### 🤖 AI & ML
 


### PR DESCRIPTION
Adds **SysKnife** to **Security & DevSecOps**.

SysKnife is a security-hardened MCP server for Linux system administration: the agent emits 189 **typed actions** instead of shell strings, a privileged daemon executes only what you approve via one-time TTL receipts, every action is written to an Ed25519-signed hash-chain audit log (public-key verifiable), with automatic rollback on atomic hosts. Works with Claude Code, Cursor, and Codex CLI. Rust, MIT. Repo: https://github.com/lacs-project/sysknife

Single entry, follows the list format, working public link.
