### PR TITLE
Add MCP Config Doctor fixtures resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Official MCP Documentation](https://modelcontextprotocol.io)
 - [MCP Specification](https://spec.modelcontextprotocol.io)
 - [Official Servers Repository](https://github.com/modelcontextprotocol/servers)
+- [MCP Config Doctor fixtures](https://github.com/supoju/mcp-config-doctor-fixtures) - Redaction-safe Codex, Gemini CLI, and VS Code MCP client configuration examples for validator tests, documentation, and bug reports.
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
 


### PR DESCRIPTION
## Summary

Adds the public [MCP Config Doctor fixtures](https://github.com/supoju/mcp-config-doctor-fixtures) repository to **Resources**.

The repository contains small, synthetic Codex, Gemini CLI, and VS Code MCP client configuration examples for validator tests, documentation, and reproducible bug reports. It includes no real credentials or machine-specific paths.

Disclosure: I maintain this fixture set as a companion to [MCP Config Doctor](https://mcpconfigdoctor.online/) and am submitting it transparently. The entry is descriptive rather than promotional.

## Checks

- Repository and linked site return HTTP 200.
- JSON fixtures parse successfully; the TOML fixture parses with Python `tomllib`.
- `git diff --check` passes.
