### PR TITLE
Add AISOTools MCP to Web & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Access the web, scrape content, and search the internet.
 | **Apify** 🎖️ | [apify/actors-mcp-server](https://github.com/apify/actors-mcp-server) | ⭐ 300+ | TS | 3,000+ pre-built web scrapers |
 | **Helium** | [connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp) | New | Python | Real-time news with bias scoring across 5,000+ sources, AI-powered options pricing, and live market data |
 | **2s.io** | [2s-io/sdk](https://github.com/2s-io/sdk) | New | TS | Keyless pay-per-call API for agents: 570+ live endpoints — web answers, patents, case law, KYB & sanctions screening, geo, weather, identity crosswalks, plus a chat/image AI gateway. Pays per request in USDC via x402, no signup or API key |
+| **AISOTools** | [shibley/aisotools-mcp-server](https://github.com/shibley/aisotools-mcp-server) | New | TS | Search a curated catalog of 1,766 AI tools by keyword, category or pricing; full records with features, pros, cons and pricing tiers; compare 2-5 products side by side; alternatives lookup. Hosted streamable HTTP, no API key |
 
 ### 📊 Productivity & Collaboration
 


### PR DESCRIPTION
One row added to **🌐 Web & Search** — it is a search server, just over a curated AI-tool catalog rather than the open web, so it sits naturally beside Exa and Perplexity.

**AISOTools MCP** — read-only MCP server over a catalog of 1,766 AI tools. Five tools: keyword/category/pricing search, full per-tool record (features, pros, cons, pricing tiers, who it's for), side-by-side comparison of 2–5 products, alternatives lookup, and category listing. Every result carries a canonical citation URL, and sponsored placements return an explicit `sponsored` boolean so an assistant can disclose them instead of passing them off as neutral.

Against your submission criteria:
- ✅ Open source (MIT) — https://github.com/shibley/aisotools-mcp-server
- ✅ Actively maintained — last commit this month
- ✅ Documentation and setup: https://aisotools.com/mcp
- ✅ Working installation, tested today: `claude mcp add --transport http aisotools https://aisotools.com/api/mcp` (`initialize` → 2025-06-18, `tools/list` → 5 tools)
- ✅ Follows the MCP spec — streamable HTTP, stateless, POST-only; also listed in the official MCP Registry as `io.github.shibley/aisotools` (status: active)

Happy to move it to 🤖 AI & ML if you'd rather it lived there.