### PR TITLE
Add: LWC - Development & Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Essential tools for software development workflows.
 | **Code Executor** | [pydantic/mcp-run-python](https://github.com/pydantic/pydantic-ai) | Official | Python | Execute Python code safely in isolated sandboxes |
 | **Docker** | [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp) | ⭐ 500+ | Go | Container management, image operations, compose support |
 | **ax** | [Necmttn/ax](https://github.com/Necmttn/ax) | New | TS | Read-only queries over local coding-agent history, sessions, tools, and costs |
+| **LWC (Local Wiki CLI)** | [JanYork/llm-wiki-cli](https://github.com/JanYork/llm-wiki-cli) | ⭐ 30+ | Rust | Local project memory with bounded read-only MCP retrieval and source citations |
 
 ### ☁️ Cloud & Infrastructure
 


### PR DESCRIPTION
## Server Information

- **Name**: LWC (Local Wiki CLI)
- **Repository**: https://github.com/JanYork/llm-wiki-cli
- **Category**: Development & Version Control
- **Language**: Rust

## Checklist

- [x] Server is open source (Apache-2.0)
- [x] README exists with installation instructions
- [x] I tested the server works
- [x] Added to correct category
- [x] Follows formatting guidelines

## Why This Server?

LWC gives coding agents durable, source-grounded project memory rather than unrestricted filesystem access. Its stdio MCP server exposes one bounded read-only `lwc_explore` tool, includes citations and provenance, and supports optional document and code knowledge graphs. It runs locally with no API keys.

## Validation

- Ran `lwc 0.14.7` MCP initialization and `tools/list` against a project workspace
- Confirmed `lwc_explore` advertises `readOnlyHint: true` and `destructiveHint: false`
- `git diff --check`