### PR TITLE
Add: SandBase Harness - Development & Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Essential tools for software development workflows.
 | **Xcode** | [r-huijts/xcode-mcp-server](https://github.com/r-huijts/xcode-mcp-server) | 🍎 | TS | iOS/macOS development: project management, builds, simulators |
 | **Code Executor** | [pydantic/mcp-run-python](https://github.com/pydantic/pydantic-ai) | Official | Python | Execute Python code safely in isolated sandboxes |
 | **Docker** | [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp) | ⭐ 500+ | Go | Container management, image operations, compose support |
+| **SandBase Harness** | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐ 638+ | TS | Self-hosted MCP runtime for agent sessions, sandboxed turns, approvals, and audit/replay |
 | **ax** | [Necmttn/ax](https://github.com/Necmttn/ax) | New | TS | Read-only queries over local coding-agent history, sessions, tools, and costs |
 
 ### ☁️ Cloud & Infrastructure


### PR DESCRIPTION
## Summary
- Add SandBase Harness to the Development & Version Control MCP catalog.
- Describe its self-hosted MCP runtime, sandboxed turns, approvals, and audit/replay capabilities.

## Verification
- Repository: https://github.com/sandbaseai/sandbase-harness
- Current release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- MCP installation guide: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md
- `git diff --check` passes.

I maintain/contribute to SandBase Harness and have disclosed that relationship. The description is intentionally factual; sandbox isolation depends on the selected backend and deployment configuration.
