### PR TITLE
Add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Essential tools for software development workflows.
 | **Code Executor** | [pydantic/mcp-run-python](https://github.com/pydantic/pydantic-ai) | Official | Python | Execute Python code safely in isolated sandboxes |
 | **Docker** | [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp) | ⭐ 500+ | Go | Container management, image operations, compose support |
 | **ax** | [Necmttn/ax](https://github.com/Necmttn/ax) | New | TS | Read-only queries over local coding-agent history, sessions, tools, and costs |
+| **SandBase Harness** | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐ 639 | TS | Local-first, self-hosted agent runtime and MCP bridge with sandboxed sessions, credentials, approvals, audit, and replay |
 
 ### ☁️ Cloud & Infrastructure
 


### PR DESCRIPTION
Adds SandBase Harness to Development & Version Control.

- TypeScript, Apache-2.0
- Local-first, self-hosted AI agent runtime and MCP bridge
- Sandboxed sessions, credentials, approvals, audit, and replay

Repository: https://github.com/sandbaseai/sandbase-harness