### PR TITLE
Add SnowSignals TrendVane under Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Handle payments, trading, and financial data.
 | **Yahoo Finance** | [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) | ⭐ 100+ | Python | Stock data and financial analysis |
 | **The Stall** | [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) | New | JS | 191 pay-per-call data tools (stocks, DeFi, options, crypto, SEC filings, macro) — no API key, USDC micropayments via x402 |
 | **AgentServices** | [vbkotecha/agentservices](https://github.com/vbkotecha/agentservices) | ⭐ 50+ | Python | 54 crypto/market data services (97 endpoints, 37 MCP tools) with x402 on-chain payments |
+| **SnowSignals TrendVane** | [snowkidind/snowsignals-mcp](https://github.com/snowkidind/snowsignals-mcp) | New | TS | Crypto market-phase classification per timeframe + BTC-derived resolution stats; free discovery, metered live reads |
 
 | **Dark-Moon** | [ASCIT31/Dark-Moon](https://github.com/ASCIT31/Dark-Moon) | | Py | Autonomous AI pentest for web, API, Active Directory and Kubernetes (GPL-3.0). |
 ### 🔒 Security & DevSecOps


### PR DESCRIPTION
Adds **SnowSignals TrendVane** in the market-data/analytics category.

Crypto market-phase classifications: which phase a coin is in per timeframe, plus a Bitcoin-derived model of how each phase historically resolves (successor odds, trend-continuation, reward-vs-drawdown with sample counts). Read-only research signal — no wallets, no trading. Two discovery tools are free (no account); live reads are metered.

- Repo: https://github.com/snowkidind/snowsignals-mcp
- Remote endpoint: https://snowsignals.io/mcp
- Official MCP registry: `io.snowsignals/snowsignals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)