### PR TITLE
Add: Neither - AI & ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Enhance AI capabilities and integrate with ML platforms.
 | **Replicate** | [awkoy/replicate-flux-mcp](https://github.com/awkoy/replicate-flux-mcp) | ⭐ 100+ | TS | Image generation via Replicate API |
 | **RunAPI** | [runapi-ai/mcp](https://github.com/runapi-ai/mcp) | New | TS | Run AI image, video, music/audio, text-to-speech, and other model API jobs |
 | **Context7** 🎖️ | [upstash/context7](https://github.com/upstash/context7) | ⭐ 500+ | TS | Up-to-date documentation for LLMs |
+| **Neither** | [stonianua/neither-mcp](https://github.com/stonianua/neither-mcp) | New | TS | Hosted company/project context graph over local stdio MCP for Cursor + Claude Desktop |
 | **NotFair** | [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) | ⭐ 2.9k+ | TS | Claude Code agent skills for SEO, Google Ads, and Meta Ads; connects via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP |
 
 ### 📱 Platform-Specific


### PR DESCRIPTION
## Summary

Add **Neither** under AI & ML — hosted company/project context graph exposed over local stdio MCP for Cursor and Claude Desktop.

- Repo: https://github.com/stonianua/neither-mcp
- Install: `npx -y @neitherai/mcp-server`
- Official Registry: `io.github.stonianua/neither-mcp` v0.1.2
- npm: `@neitherai/mcp-server`

## Disclosure

I am the author/maintainer of Neither MCP.

## Checklist

- [x] Open source on GitHub
- [x] Documented install (npx stdio)
- [x] MCP compliant (stdio)
- [x] Not already listed